### PR TITLE
Updated bookmarklet to use URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Any time you're on a Github repo you can click the bookmarklet
 and it'll bring up the Active Forks of that repo.
 
 ```javascript
-javascript:thing=document.URL.match(/github.com\/([A-z][\w\-]*\/[A-z][\w\-]*)/);if (thing){ var newPage = 'https://techgaun.github.io/active-forks/index.html#'+thing[1];open(newPage%20,'targetname')%20}%20else%20{window.alert("Not%20a%20valid%20GitHub%20page");}
+javascript:thing=document.URL.match(/github.com\/([A-z][\w\-]*\/[A-z][\w\-]*)/);if (thing){var newPage = 'https://techgaun.github.io/active-forks/index.html#'+thing[1];open(newPage%20,'targetname')%20}%20else%20{window.alert("Not%20a%20valid%20GitHub%20page");}
 ```
 
 ![Screenshot](screenshot.png "Active Forks in Action")


### PR DESCRIPTION
Updated bookmarklet to use page URL rather than title. URL is more reliable than Title. Title was not working any more.